### PR TITLE
feat: Allow overwriting status codes from the proxied upstream

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -82,23 +82,24 @@ type OAuthProxy struct {
 
 	SignInPath string
 
-	allowedRoutes        []allowedRoute
-	apiRoutes            []apiRoute
-	redirectURL          *url.URL // the url to receive requests at
-	relativeRedirectURL  bool
-	whitelistDomains     []string
-	provider             providers.Provider
-	sessionStore         sessionsapi.SessionStore
-	ProxyPrefix          string
-	basicAuthValidator   basic.Validator
-	basicAuthGroups      []string
-	SkipProviderButton   bool
-	skipAuthPreflight    bool
-	skipJwtBearerTokens  bool
-	forceJSONErrors      bool
-	allowQuerySemicolons bool
-	realClientIPParser   ipapi.RealClientIPParser
-	trustedIPs           *ip.NetSet
+	allowedRoutes           []allowedRoute
+	apiRoutes               []apiRoute
+	redirectURL             *url.URL // the url to receive requests at
+	relativeRedirectURL     bool
+	whitelistDomains        []string
+	provider                providers.Provider
+	sessionStore            sessionsapi.SessionStore
+	ProxyPrefix             string
+	basicAuthValidator      basic.Validator
+	basicAuthGroups         []string
+	SkipProviderButton      bool
+	skipAuthPreflight       bool
+	skipJwtBearerTokens     bool
+	overwriteUpstreamStatus int
+	forceJSONErrors         bool
+	allowQuerySemicolons    bool
+	realClientIPParser      ipapi.RealClientIPParser
+	trustedIPs              *ip.NetSet
 
 	sessionChain      alice.Chain
 	headersChain      alice.Chain
@@ -219,21 +220,22 @@ func NewOAuthProxy(ctx context.Context, opts *options.Options, validator func(st
 
 		SignInPath: fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 
-		ProxyPrefix:          opts.ProxyPrefix,
-		provider:             provider,
-		sessionStore:         sessionStore,
-		redirectURL:          redirectURL,
-		relativeRedirectURL:  opts.RelativeRedirectURL,
-		apiRoutes:            apiRoutes,
-		allowedRoutes:        allowedRoutes,
-		whitelistDomains:     opts.WhitelistDomains,
-		skipAuthPreflight:    opts.SkipAuthPreflight,
-		skipJwtBearerTokens:  opts.SkipJwtBearerTokens,
-		realClientIPParser:   opts.GetRealClientIPParser(),
-		SkipProviderButton:   opts.SkipProviderButton,
-		forceJSONErrors:      opts.ForceJSONErrors,
-		allowQuerySemicolons: opts.AllowQuerySemicolons,
-		trustedIPs:           trustedIPs,
+		ProxyPrefix:             opts.ProxyPrefix,
+		provider:                provider,
+		sessionStore:            sessionStore,
+		redirectURL:             redirectURL,
+		relativeRedirectURL:     opts.RelativeRedirectURL,
+		apiRoutes:               apiRoutes,
+		allowedRoutes:           allowedRoutes,
+		whitelistDomains:        opts.WhitelistDomains,
+		skipAuthPreflight:       opts.SkipAuthPreflight,
+		skipJwtBearerTokens:     opts.SkipJwtBearerTokens,
+		overwriteUpstreamStatus: opts.OverwriteUpstreamStatus,
+		realClientIPParser:      opts.GetRealClientIPParser(),
+		SkipProviderButton:      opts.SkipProviderButton,
+		forceJSONErrors:         opts.ForceJSONErrors,
+		allowQuerySemicolons:    opts.AllowQuerySemicolons,
+		trustedIPs:              trustedIPs,
 
 		basicAuthValidator: basicAuthValidator,
 		basicAuthGroups:    opts.HtpasswdUserGroups,
@@ -995,6 +997,38 @@ func (p *OAuthProxy) AuthOnly(rw http.ResponseWriter, req *http.Request) {
 	})).ServeHTTP(rw, req)
 }
 
+// Overwrite response code
+type responseCodeOverwriteWriter struct {
+	http.ResponseWriter
+	request      *http.Request
+	written      bool
+	targetStatus int
+}
+
+func (crw *responseCodeOverwriteWriter) WriteHeader(code int) {
+	// TODO: Ideally, another custom writer would have incremented the status. Make
+	// sure to have this wrapper execute *after* the counter though -
+	// otherwise you'll count the altered status codes
+	middleware.UpstreamResponseStatusCounter().WithLabelValues(fmt.Sprintf("%d", code)).Inc()
+
+	if code != crw.targetStatus {
+		logger.Errorf("requestCodeOverwriteWriter: overwriting status code %d -> %d for [ %s%s ]", code, crw.targetStatus, crw.request.Host, crw.request.URL.Path)
+	}
+
+	crw.written = true
+	crw.ResponseWriter.WriteHeader(crw.targetStatus)
+}
+
+func (crw *responseCodeOverwriteWriter) Write(b []byte) (int, error) {
+	if !crw.written {
+		logger.Errorf("requestCodeOverwriteWriter: overwriting status code ?? -> %d for [ %s%s ]", crw.targetStatus, crw.request.Host, crw.request.URL.Path)
+		crw.written = true
+		crw.WriteHeader(crw.targetStatus)
+	}
+
+	return crw.ResponseWriter.Write(b)
+}
+
 // Proxy proxies the user request if the user is authenticated else it prompts
 // them to authenticate
 func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
@@ -1003,7 +1037,15 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 	case nil:
 		// we are authenticated
 		p.addHeadersForProxying(rw, session)
-		p.headersChain.Then(p.upstreamProxy).ServeHTTP(rw, req)
+		p.headersChain.Then(http.HandlerFunc(func(rw http.ResponseWriter, innerReq *http.Request) {
+			customRW := rw
+
+			if p.overwriteUpstreamStatus > 0 {
+				customRW = &responseCodeOverwriteWriter{ResponseWriter: rw, request: innerReq, targetStatus: p.overwriteUpstreamStatus}
+			}
+
+			p.upstreamProxy.ServeHTTP(customRW, innerReq)
+		})).ServeHTTP(rw, req)
 	case ErrNeedsLogin:
 		// we need to send the user to a login screen
 		if p.forceJSONErrors || isAjax(req) || p.isAPIPath(req) {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -3467,3 +3467,189 @@ func TestGetOAuthRedirectURI(t *testing.T) {
 		})
 	}
 }
+
+func TestResponseCodeOverwriteWriter(t *testing.T) {
+	t.Run("overwrites different error status codes", func(t *testing.T) {
+		// Test various error status codes
+		testCases := []int{
+			http.StatusBadRequest,          // 400
+			http.StatusUnauthorized,        // 401
+			http.StatusForbidden,           // 403
+			http.StatusNotFound,            // 404
+			http.StatusInternalServerError, // 500
+			http.StatusBadGateway,          // 502
+			http.StatusServiceUnavailable,  // 503
+		}
+
+		for _, statusCode := range testCases {
+			t.Run(fmt.Sprintf("status_%d", statusCode), func(t *testing.T) {
+				recorder := httptest.NewRecorder()
+				customRW := &responseCodeOverwriteWriter{ResponseWriter: recorder, targetStatus: http.StatusOK}
+
+				customRW.WriteHeader(statusCode)
+				assert.Equal(t, http.StatusOK, recorder.Code,
+					fmt.Sprintf("Status %d should be overwritten to 200", statusCode))
+			})
+		}
+	})
+
+	t.Run("handles multiple Write calls correctly", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		customRW := &responseCodeOverwriteWriter{ResponseWriter: recorder, targetStatus: http.StatusOK}
+
+		// First write should call WriteHeader(200)
+		_, err := customRW.Write([]byte("first"))
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, recorder.Code, "First Write should set status to 200")
+
+		// Second write should not change status
+		_, err = customRW.Write([]byte("second"))
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, recorder.Code, "Second Write should keep status as 200")
+
+		// Body should contain both writes
+		assert.Equal(t, "firstsecond", recorder.Body.String(), "Body should contain all written content")
+	})
+
+	t.Run("handles empty Write calls", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		customRW := &responseCodeOverwriteWriter{ResponseWriter: recorder, targetStatus: http.StatusOK}
+
+		// Write empty bytes
+		_, err := customRW.Write([]byte{})
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, recorder.Code, "Empty Write should still set status to 200")
+		assert.Equal(t, "", recorder.Body.String(), "Body should be empty")
+	})
+}
+
+func TestProxyOverwriteUpstreamStatus(t *testing.T) {
+	tests := []struct {
+		name            string
+		upstreamStatus  int
+		upstreamBody    string
+		expectStatus    int
+		expectBody      string
+		overwriteStatus int
+	}{
+		{
+			name:            "already returns 200",
+			upstreamStatus:  http.StatusOK,
+			upstreamBody:    "Success",
+			expectStatus:    http.StatusOK, // Should remain 200
+			expectBody:      "Success",
+			overwriteStatus: 200,
+		},
+		{
+			name:            "naked 503 page",
+			upstreamStatus:  http.StatusServiceUnavailable,
+			upstreamBody:    "",
+			expectStatus:    200, // Should be overwritten to 200
+			expectBody:      "",
+			overwriteStatus: 200,
+		},
+		{
+			name:            "503 page with content",
+			upstreamStatus:  http.StatusServiceUnavailable,
+			upstreamBody:    "Service temporarily unavailable",
+			expectStatus:    200, // Should be overwritten to 200
+			expectBody:      "Service temporarily unavailable",
+			overwriteStatus: 200,
+		},
+		{
+			name:            "503 page with content - overwrite disabled",
+			upstreamStatus:  http.StatusServiceUnavailable,
+			upstreamBody:    "Service temporarily unavailable",
+			expectStatus:    http.StatusServiceUnavailable, // Should remain 503
+			expectBody:      "Service temporarily unavailable",
+			overwriteStatus: 0,
+		},
+		{
+			name:            "404 page overwritten to 418 (I'm a teapot)",
+			upstreamStatus:  http.StatusNotFound,
+			upstreamBody:    "Not Found",
+			expectStatus:    418, // Should be overwritten to 418
+			expectBody:      "Not Found",
+			overwriteStatus: 418,
+		},
+		{
+			name:            "500 page overwritten to 202 (Accepted)",
+			upstreamStatus:  http.StatusInternalServerError,
+			upstreamBody:    "Internal Server Error",
+			expectStatus:    202, // Should be overwritten to 202
+			expectBody:      "Internal Server Error",
+			overwriteStatus: 202,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock upstream server that returns the specified status and body
+			upstreamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.upstreamStatus)
+				if tt.upstreamBody != "" {
+					w.Write([]byte(tt.upstreamBody))
+				}
+			}))
+			t.Cleanup(upstreamServer.Close)
+
+			// Create test options with overwriteUpstreamStatus setting
+			opts := baseTestOptions()
+			opts.OverwriteUpstreamStatus = tt.overwriteStatus
+			opts.UpstreamServers = options.UpstreamConfig{
+				Upstreams: []options.Upstream{
+					{
+						ID:   upstreamServer.URL,
+						Path: "/",
+						URI:  upstreamServer.URL,
+					},
+				},
+			}
+
+			// Set Cookie.Refresh to create proxy.AesCipher (needed for access_token encryption)
+			opts.Cookie.Refresh = time.Hour
+
+			// Validate options before creating proxy
+			err := validation.Validate(opts)
+			require.NoError(t, err)
+
+			// Create the proxy
+			proxy, err := NewOAuthProxy(context.Background(), opts, func(email string) bool { return true })
+			require.NoError(t, err)
+
+			// Verify the flag is set correctly
+			assert.Equal(t, tt.overwriteStatus, proxy.overwriteUpstreamStatus,
+				fmt.Sprintf("overwriteUpstreamStatus should be %d for test case: %s", tt.overwriteStatus, tt.name))
+
+			// Create a mock session and save it to bypass OAuth flow
+			created := time.Now()
+			session := &sessions.SessionState{
+				User:        "testuser",
+				Email:       "test@example.com",
+				AccessToken: "test-token",
+				CreatedAt:   &created,
+			}
+
+			// Create a test request and response
+			req := httptest.NewRequest("GET", "/", nil)
+			rw := httptest.NewRecorder()
+
+			// Save the session to get a valid cookie
+			err = proxy.sessionStore.Save(rw, req, session)
+			require.NoError(t, err)
+
+			// Extract the cookie and add it to our test request
+			cookie := rw.Header().Values("Set-Cookie")[0]
+			req.Header.Set("Cookie", cookie)
+
+			// Now test the actual proxy call
+			proxy.ServeHTTP(rw, req)
+
+			// Validate the response
+			assert.Equal(t, tt.expectStatus, rw.Code,
+				fmt.Sprintf("Status should be %d for test case: %s", tt.expectStatus, tt.name))
+			assert.Equal(t, tt.expectBody, rw.Body.String(),
+				fmt.Sprintf("Body should match for test case: %s", tt.name))
+		})
+	}
+}

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	SkipAuthRegex            []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
 	SkipAuthRoutes           []string `flag:"skip-auth-route" cfg:"skip_auth_routes"`
 	SkipJwtBearerTokens      bool     `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
+	OverwriteUpstreamStatus  int      `flag:"overwrite-upstream-status" cfg:"overwrite_upstream_status"`
 	BearerTokenLoginFallback bool     `flag:"bearer-token-login-fallback" cfg:"bearer_token_login_fallback"`
 	ExtraJwtIssuers          []string `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
 	SkipProviderButton       bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
@@ -134,6 +135,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS providers")
 	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.Bool("bearer-token-login-fallback", true, "if skip-jwt-bearer-tokens is set, fall back to normal login redirect with an invalid JWT. If false, 403 instead")
+	flagSet.Int("overwrite-upstream-status", 0, "overwrite upstream response status codes to specified value (0 = disabled, 200 = OK, etc.)")
 	flagSet.Bool("force-json-errors", false, "will force JSON errors instead of HTTP error pages or redirects")
 	flagSet.Bool("encode-state", false, "will encode oauth state with base64")
 	flagSet.Bool("allow-query-semicolons", false, "allow the use of semicolons in query args")

--- a/pkg/middleware/metrics.go
+++ b/pkg/middleware/metrics.go
@@ -120,3 +120,31 @@ func registerRequestsLatencyHistogram(registerer prometheus.Registerer) *prometh
 
 	return histogram
 }
+
+// registerUpstreamResponseStatusCounter registers the 'oauth2_proxy_upstream_responses_total' metric
+// This keeps a tally of all upstream responses bucketed by their HTTP status code
+func registerUpstreamResponseStatusCounter(registerer prometheus.Registerer) *prometheus.CounterVec {
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "oauth2_proxy_upstream_responses_total",
+			Help: "Total number of upstream responses by HTTP status code.",
+		},
+		[]string{"code"},
+	)
+
+	if err := registerer.Register(counter); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			counter = are.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			panic(err)
+		}
+	}
+
+	return counter
+}
+
+// UpstreamResponseStatusCounter returns the upstream response status counter
+// metric for others to consume. Is this a good way to expose it? I dunno!
+func UpstreamResponseStatusCounter() *prometheus.CounterVec {
+	return registerUpstreamResponseStatusCounter(prometheus.DefaultRegisterer)
+}


### PR DESCRIPTION
Gives a knob to allow changing the upstream's http status to whatever we desire. This allows glossing over problems in the upstream.

The original sin is something to do with the collector's exporting being a little out of wack, but...we can't figure it out in an appropriate timeframe.

As sssuuuccchhh, we add some logging & metrics around what kind of responses we're seeing to be a little wiser, and hopefully we can destroy this at a later date! Yay!

Resolves MIG-8854.