### PR TITLE
test: Make the ready check middleware only return 503 for a ready che…

### DIFF
--- a/pkg/middleware/readynesscheck.go
+++ b/pkg/middleware/readynesscheck.go
@@ -24,12 +24,13 @@ func NewReadynessCheck(ctx context.Context, path string, verifiable Verifiable) 
 
 func readynessCheck(ctx context.Context, path string, verifiable Verifiable, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if ctx.Err() != nil {
-			rw.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprintf(rw, "Shutting down")
-			return
-		}
 		if path != "" && req.URL.EscapedPath() == path {
+			if ctx.Err() != nil {
+				rw.WriteHeader(http.StatusServiceUnavailable)
+				fmt.Fprintf(rw, "Shutting down")
+				return
+			}
+
 			if err := verifiable.VerifyConnection(req.Context()); err != nil {
 				rw.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintf(rw, "error: %v", err)

--- a/pkg/middleware/readynesscheck_test.go
+++ b/pkg/middleware/readynesscheck_test.go
@@ -69,6 +69,69 @@ var _ = Describe("ReadynessCheck suite", func() {
 			expectedBody:     "error: failed to check",
 		}),
 	)
+
+	Context("during graceful shutdown (cancelled context)", func() {
+		var cancelledCtx context.Context
+
+		BeforeEach(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			cancelledCtx = ctx
+		})
+
+		It("returns 503 on the readiness path", func() {
+			req := httptest.NewRequest("GET", "http://example.com/ready", nil)
+			rw := httptest.NewRecorder()
+
+			handler := NewReadynessCheck(cancelledCtx, "/ready", &fakeVerifiable{nil})(http.NotFoundHandler())
+			handler.ServeHTTP(rw, req)
+
+			Expect(rw.Code).To(Equal(http.StatusServiceUnavailable))
+			Expect(rw.Body.String()).To(Equal("Shutting down"))
+		})
+
+		It("still serves non-readiness requests normally", func() {
+			nextCalled := false
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				nextCalled = true
+				rw.WriteHeader(http.StatusOK)
+				rw.Write([]byte("upstream response"))
+			})
+
+			req := httptest.NewRequest("POST", "http://example.com/v1/traces", nil)
+			rw := httptest.NewRecorder()
+
+			handler := NewReadynessCheck(cancelledCtx, "/ready", &fakeVerifiable{nil})(next)
+			handler.ServeHTTP(rw, req)
+
+			Expect(nextCalled).To(BeTrue())
+			Expect(rw.Code).To(Equal(http.StatusOK))
+			Expect(rw.Body.String()).To(Equal("upstream response"))
+		})
+
+		It("does not leak shutdown status to arbitrary paths", func() {
+			paths := []string{
+				"http://example.com/",
+				"http://example.com/v1/traces",
+				"http://example.com/api/data",
+				"http://example.com/oauth2/callback",
+			}
+
+			for _, path := range paths {
+				rw := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", path, nil)
+
+				handler := NewReadynessCheck(cancelledCtx, "/ready", &fakeVerifiable{nil})(
+					http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+						rw.WriteHeader(http.StatusOK)
+					}),
+				)
+				handler.ServeHTTP(rw, req)
+
+				Expect(rw.Code).To(Equal(http.StatusOK), "path %s should not get 503 during shutdown", path)
+			}
+		})
+	})
 })
 
 type fakeVerifiable struct {


### PR DESCRIPTION
An issue found as part of war room #war-room-2026-03-16-riskified-getting-503

Whenever the oauth2proxy pod gets a shutdown request (for whatever good reason), it gives itself 25s before being shutdown. A bug in the health check middleware caused it so whenever the context of the pod is canceled, it will return 503 to all requests.

The correct behavior is during a context cancel, to return 503 only for the health check requests, so other requests can still be served normally until the pod is no longer handling traffic