### PR TITLE
MIG-11558: feat(jwt_session): log validated JWT key_id and path

### DIFF
--- a/pkg/middleware/jwt_session.go
+++ b/pkg/middleware/jwt_session.go
@@ -58,6 +58,15 @@ func (j *jwtSessionLoader) loadSession(next http.Handler) http.Handler {
 			}
 		}
 
+		if session != nil {
+			// Log validated JWT identity so M2M requests can be correlated back
+			// to the originating Descope access key. session.User is populated
+			// from the JWT 'sub' claim by the OIDC verifier (CreateTokenToSessionFunc)
+			// — no manual decoding needed (MIG-11558).
+			logger.Printf("jwt session loaded: key_id=%s path=%s exp=%v",
+				session.User, req.URL.Path, session.ExpiresOn)
+		}
+
 		// Add the session to the scope if it was found
 		scope.Session = session
 		next.ServeHTTP(rw, req)


### PR DESCRIPTION
## MIG-11558 — focused scope

Add a success-path log line in the JWT session middleware so every authenticated M2M request can be correlated back to its originating Descope access key.

### The clean part — no manual decoding
`session.User` is populated from the JWT `sub` claim by `CreateTokenToSessionFunc` (see `pkg/apis/middleware/session.go`). The OIDC verifier (`go-oidc`) already parsed and validated the JWT, so we just read what it produced — no new parsing code, no new dependencies, no attack surface.

### Change
- `pkg/middleware/jwt_session.go` — one log line after `getJwtSession` returns successfully

### Fields logged
- `key_id` = `session.User` (= JWT `sub` claim = Descope Access Key ID, joins to `tenant_access_key.refId`)
- `path` = `req.URL.Path` (sensors, collector, and human users hit different upstreams via different paths — this distinguishes them)
- `exp` = `session.ExpiresOn` (TTL visibility)

### Out of scope
- The existing error-path log (which logs the raw `Authorization` header) is **not** touched. That's a separate concern worth a focused PR — either remove the token logging entirely or use a vetted library. Out of scope here.

Linear: https://linear.app/miggo/issue/MIG-11558

🤖 Generated with [Claude Code](https://claude.com/claude-code)